### PR TITLE
fixed bug in the parametried test

### DIFF
--- a/UnitTesting_withC#/ParametrizedTesting/NUnitTest.ParametrizedTest/UnitTest1.cs
+++ b/UnitTesting_withC#/ParametrizedTesting/NUnitTest.ParametrizedTest/UnitTest1.cs
@@ -61,9 +61,9 @@ namespace NUnitTest.ParametrizedTest
 
 
         [Test]
-        [TestCase(2,1,1)]  // Parametrized testing
-        [TestCase(1,2,2)]
-        [TestCase(2,2,2)]
+        [TestCase(2,1,2)]  // Parametrized testing case when a > b, result is a
+        [TestCase(1,3,3)]  //Parametrized testing case when a < b, result is b
+        [TestCase(3,3,3)]  // Parametrized testing case when a = b, result is a
         public void Max_WhenCalled_ReturnGreaterArge(int a, int b, int expectedResult) 
         {
             var result = _math.Max(a,b);


### PR DESCRIPTION
**PARAMETRIEZED TESTING ** - a clean way test multiple scenarios / test cases


`        [Test]
        [TestCase(2,1,2)]  // Parametrized testing case when a > b, result is a
        [TestCase(1,3,3)]  //Parametrized testing case when a < b, result is b
        [TestCase(3,3,3)]  // Parametrized testing case when a = b, result is a
        public void Max_WhenCalled_ReturnGreaterArge(int a, int b, int expectedResult) 
        {
            var result = _math.Max(a,b);

            Assert.That(result, Is.EqualTo(expectedResult));
        }`